### PR TITLE
Fix typo in package frameworks

### DIFF
--- a/RespringNotifier/Makefile
+++ b/RespringNotifier/Makefile
@@ -4,7 +4,7 @@ include theos/makefiles/common.mk
 TWEAK_NAME = RespringNotifier
 RespringNotifier_FILES = Tweak.xm
 RespringNotifier_FRAMEWORKS = UIKit
-RespringNotifier_PRIVATE_FRAMEOWRKS = Preferences
+RespringNotifier_PRIVATE_FRAMEWORKS = Preferences
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 


### PR DESCRIPTION
Fix typo in the Makefile for RespringNotifier causing compiler to not work